### PR TITLE
Improve model robustness via improved image quality

### DIFF
--- a/preprocess_mitoses.py
+++ b/preprocess_mitoses.py
@@ -350,7 +350,8 @@ def save_patch(patch, path, lab, case, region, row, col, rotation, row_shift, co
   # TODO: extract filename generation and arg extraction into separate functions
   filename = f"{lab}_{case}_{region}_{row}_{col}_{rotation}_{row_shift}_{col_shift}{suffix}.{ext}"
   file_path = os.path.join(path, filename)
-  Image.fromarray(patch).save(file_path)
+  # TODO: explore saving this as a PNG instead
+  Image.fromarray(patch).save(file_path, subsampling=0, quality=100)
 
 
 def preprocess(images_path, labels_path, base_save_path, train_size, patch_size, rotations_train,

--- a/train_mitoses.py
+++ b/train_mitoses.py
@@ -31,7 +31,8 @@ def get_image(filename, patch_size):
     type float32 and values in [0, 1).
   """
   image_string = tf.read_file(filename)
-  image = tf.image.decode_jpeg(image_string, channels=3)  # shape (h,w,c), uint8 in [0, 255]
+  # shape (h,w,c), uint8 in [0, 255]:
+  image = tf.image.decode_jpeg(image_string, channels=3, dct_method='INTEGER_ACCURATE')
   image = tf.image.convert_image_dtype(image, dtype=tf.float32)  # float32 [0, 1)
   image = tf.image.resize_images(image, [patch_size, patch_size])  # float32 [0, 1)
   #with tf.control_dependencies([tf.assert_type(image, tf.float32, image.dtype)]):


### PR DESCRIPTION
Recent experiments uncovered an issue in which there was a difference in
performance between training/evaluation and prediction code paths.  A
deeper inspection uncovered two issues:

  1. By default, PIL saves jpeg files at a low quality, and thus
  predictions made on the original high-quality tiff images yielded
  different predictions than on default jpeg versions of the files.
  The jpeg images have a different distribution than that of the tiff
  images, and thus models up to this point that were trained on the
  relatively lower-quality jpeg images performed poorly on the
  higher-quality tiff images.  Although we cannot yet train directly on
  tiff images while using TensorFlow's Dataset API, which is used in
  order to keep the GPUs fully saturated, this commit updates the
  preprocessing code to save 100% quality jpeg images.  In the future,
  we may swap this out with a lossless png format.
  2. By default, TensorFlow decodes jpeg images with a faster, but
  relatively lower-quality, decompression algorithm which yields
  different results than reading the jpeg directly with PIL.  Thus, at
  prediction time, even with high-quality jpeg images, the results are
  still slightly different.  This commit improves the training script to
  have TensorFlow use a more accurate decompression algorithm.

Thanks to @feihugis for the experiments that uncovered the cause of
these issues.