### PR TITLE
Improve image quality (PNGs) and improve gen_dense_coords to allow for reuse during prediction time

### DIFF
--- a/preprocess_mitoses.py
+++ b/preprocess_mitoses.py
@@ -535,10 +535,10 @@ if __name__ == "__main__":
            "(default: `round(patch_size/4)`)")
   parser.add_argument("--stride_train", type=int,
       help="number of pixels by which to shift in the sliding window for normal patches in the "\
-           "training set (default: `patch_size/4`)")
+           "training set (default: `patch_size*(3/4)`)")
   parser.add_argument("--stride_val", type=int,
       help="number of pixels by which to shift in the sliding window for normal patches in the "\
-           "validation set (default: `patch_size/4`)")
+           "validation set (default: `patch_size*(3/4)`)")
   parser.add_argument("--overlap_threshold", type=lambda x: check_float_range(x, 0, 1),
       default=0.25, help="decimal inclusive upper bound on the percentage of overlap of normal "\
                          "patches with mitosis patches (default: %(default)s)")
@@ -569,10 +569,10 @@ if __name__ == "__main__":
     args.max_shift = round(args.patch_size/4)
 
   if args.stride_train is None:
-    args.stride_train = round(args.patch_size/4)
+    args.stride_train = round(args.patch_size*(3/4))
 
   if args.stride_val is None:
-    args.stride_val = round(args.patch_size/4)
+    args.stride_val = round(args.patch_size*(3/4))
 
   # create a random seed if needed
   if args.seed is None:

--- a/preprocess_mitoses.py
+++ b/preprocess_mitoses.py
@@ -535,10 +535,10 @@ if __name__ == "__main__":
            "(default: `round(patch_size/4)`)")
   parser.add_argument("--stride_train", type=int,
       help="number of pixels by which to shift in the sliding window for normal patches in the "\
-           "training set (default: `patch_size`)")
+           "training set (default: `patch_size/4`)")
   parser.add_argument("--stride_val", type=int,
       help="number of pixels by which to shift in the sliding window for normal patches in the "\
-           "validation set (default: `patch_size`)")
+           "validation set (default: `patch_size/4`)")
   parser.add_argument("--overlap_threshold", type=lambda x: check_float_range(x, 0, 1),
       default=0.25, help="decimal inclusive upper bound on the percentage of overlap of normal "\
                          "patches with mitosis patches (default: %(default)s)")
@@ -569,10 +569,10 @@ if __name__ == "__main__":
     args.max_shift = round(args.patch_size/4)
 
   if args.stride_train is None:
-    args.stride_train = args.patch_size
+    args.stride_train = round(args.patch_size/4)
 
   if args.stride_val is None:
-    args.stride_val = args.patch_size
+    args.stride_val = round(args.patch_size/4)
 
   # create a random seed if needed
   if args.seed is None:

--- a/train_mitoses.py
+++ b/train_mitoses.py
@@ -32,7 +32,7 @@ def get_image(filename, patch_size):
   """
   image_string = tf.read_file(filename)
   # shape (h,w,c), uint8 in [0, 255]:
-  image = tf.image.decode_jpeg(image_string, channels=3, dct_method='INTEGER_ACCURATE')
+  image = tf.image.decode_png(image_string, channels=3),
   image = tf.image.convert_image_dtype(image, dtype=tf.float32)  # float32 [0, 1)
   image = tf.image.resize_images(image, [patch_size, patch_size])  # float32 [0, 1)
   #with tf.control_dependencies([tf.assert_type(image, tf.float32, image.dtype)]):
@@ -259,7 +259,8 @@ def create_dataset(path, model_name, patch_size, batch_size, shuffle, augmentati
     A Dataset object.
   """
   # read & process images
-  dataset = tf.data.Dataset.list_files(os.path.join(path, "*", "*.jpg"))
+  #dataset = tf.data.Dataset.list_files(os.path.join(path, "*", "*.{png,jpg}"))  # not supported
+  dataset = tf.data.Dataset.list_files(os.path.join(path, "*", "*.png"))
 
   if shuffle:
     dataset = dataset.shuffle(500000)
@@ -877,7 +878,7 @@ def main(args=None):
            "(default: %%y-%%m-%%d_%%H:%%M:%%S_{model})")
   parser.add_argument("--exp_name_suffix", default=None,
       help="suffix to add to experiment name (default: all parameters concatenated together)")
-  parser.add_argument("--model", default="vgg",
+  parser.add_argument("--model", default="vgg", choices=["logreg", "vgg", "vgg19", "resnet"],
       help="name of the model to use in ['logreg', 'vgg', 'vgg19', 'resnet'] "\
            "(default: %(default)s)")
   parser.add_argument("--patch_size", type=int, default=64,

--- a/train_mitoses.py
+++ b/train_mitoses.py
@@ -1023,6 +1023,8 @@ def test_get_image(tmpdir):
   assert image.dtype == np.float32
   assert np.min(image) >= 0
   assert np.max(image) < 1
+  assert np.allclose(x.astype(np.float32) / 255, image)
+  assert np.allclose((x / 255).astype(np.float32), image)
 
 
 def test_get_label():
@@ -1107,7 +1109,7 @@ def test_normalize_unnormalize():
     assert np.all(np.max(x_norm, axis=(0,1)) < 255 - means)
     assert np.all(np.min(x_norm, axis=(0,1)) < 0)
     assert np.all(np.min(x_norm, axis=(0,1)) > 0 - means)
-    assert np.allclose(x_unnorm, x_np, rtol=5.e-5)  #, atol=1e-7)
+    assert np.allclose(x_unnorm, x_np, rtol=1e-4)  #, atol=1e-7)
 
   # batch of examples
   def test_batch(x_batch_norm, x_batch_unnorm):
@@ -1166,7 +1168,7 @@ def test_normalize_unnormalize():
     assert np.all(np.max(x_norm, axis=(0,1)) > 0)
     assert np.all(np.min(x_norm, axis=(0,1)) >= -1)
     assert np.all(np.min(x_norm, axis=(0,1)) < 0)
-    assert np.allclose(x_unnorm, x_np, rtol=5.e-5)  #, atol=1e-7)
+    assert np.allclose(x_unnorm, x_np, rtol=1e-4)  #, atol=1e-7)
 
   # batch of examples
   def test_batch(x_batch_norm, x_batch_unnorm):


### PR DESCRIPTION
This updates the preproc/train/eval code to use lossless PNG image files instead of JPEGs in order to make the models more robust during prediction time (and hopefully improve the training performance as well).  Additionally, this updates `gen_dense_coords` to include coordinates for patches with padding along the left and top edges.  With appropriate striding, the right and bottom edges can also be included.