### PR TITLE
Add mitosis oversampling via class-aware sampling during training

### DIFF
--- a/eval_mitoses.py
+++ b/eval_mitoses.py
@@ -44,7 +44,7 @@ def evaluate(patches_path, patch_size, batch_size, model, model_name, prob_thres
   # data
   with tf.name_scope("data"):
     dataset = create_dataset(patches_path, model_name, patch_size, batch_size, False, False,
-        marginalization, threads, prefetch_batches, None)
+        marginalization, False, threads, prefetch_batches, None)
 
     iterator = tf.data.Iterator.from_structure(dataset.output_types, dataset.output_shapes)
     data_init_op = iterator.make_initializer(dataset)

--- a/hyperparam_tune_mitoses.py
+++ b/hyperparam_tune_mitoses.py
@@ -59,6 +59,9 @@ def main(args=None):
       help="use noise marginalization when evaluating the validation set. if this is set, then "\
            "the validation batch_size must be divisible by 4, or equal to 1 for no augmentation "\
            "(default: %(default)s)")
+  parser.add_argument("--oversample", default=False, action="store_true",
+      help="oversample the minority mitosis class during training via class-aware sampling "\
+           "(default: %(default)s)")
   parser.add_argument("--threads", type=int, default=5,
       help="number of threads for dataset parallel processing; note: this will cause "\
            "non-reproducibility for values > 1 (default: %(default)s)")
@@ -122,6 +125,9 @@ def main(args=None):
 
     if args.marginalize:
       train_args.append("--marginalize")
+
+    if args.oversample:
+      train_args.append("--oversample")
 
     train_args.append(f"--threads={args.threads}")
 


### PR DESCRIPTION
This adds minority mitosis oversampling via class-aware sampling in
which we sampling even numbers of mitosis and normal patches for each
mini-batch, sampling with replacement from the mitosis samples until we
run out of normal samples.